### PR TITLE
Add Spanish alphabet dataset builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Pipeline: `scanned page -> character detection -> character classification -> pe
 | Stage | Status | Branch |
 | ----- | ------ | ------ |
 | Pipeline skeleton (types, stages, orchestrator, CLI) | ✅ | `ft/pipeline-skeleton` |
-| Spanish alphabet dataset builder (A-Z + ñ, TTF + real samples) | ⬜ | `ft/alphabet-dataset` |
+| Spanish alphabet dataset builder (A-Z + ñ, TTF + real samples) | ✅ | `ft/alphabet-dataset` |
 | Character detector (YOLOv8, MSER fallback) | ⬜ | `ft/char-detector` |
 | Character classifier (CNN) | ⬜ | `ft/char-classifier` |
 | Per-character style transfer (pix2pix / latent AE) | ⬜ | `ft/style-stylizer` |
@@ -23,6 +23,14 @@ Run the pipeline today (MSER detection + baseline cleanup stylizer):
 ```
 python improve_document.py --input documents/page.jpeg --output documents/improved.png --alpha 0.8
 ```
+
+Build the alphabet dataset (drop your pretty style `.ttf` fonts into `fonts/` first):
+
+```
+python build_alphabet.py --fonts "fonts/**/*.ttf" --out dataset/alphabet --size 64
+```
+
+Ingest your own handwriting crops later with `--samples samples/`, where `samples/` contains one directory per character class.
 
 ## Experiments
 

--- a/build_alphabet.py
+++ b/build_alphabet.py
@@ -1,0 +1,42 @@
+import argparse
+import logging
+
+from call_ai_grapher.dataset import AlphabetDatasetBuilder, DEFAULT_ALPHABET, class_counts, find_fonts
+
+
+def _parse_args():
+    parser = argparse.ArgumentParser(description="Build the Spanish alphabet dataset")
+    parser.add_argument("--fonts", default="fonts/**/*.ttf", help="glob pattern with the pretty style .ttf fonts")
+    parser.add_argument("--samples", default=None, help="optional directory with real handwriting crops per class")
+    parser.add_argument("--out", default="dataset/alphabet", help="output dataset directory")
+    parser.add_argument("--size", type=int, default=64, help="normalized image size in pixels")
+    return parser.parse_args()
+
+
+def _main():
+    try:
+        logging.basicConfig(format="%(asctime)-15s %(levelname)s %(message)s", level=logging.INFO)
+        args = _parse_args()
+
+        builder = AlphabetDatasetBuilder(chars=DEFAULT_ALPHABET, size=args.size)
+
+        fonts = find_fonts(args.fonts)
+        if fonts:
+            counts = builder.build_from_fonts(fonts, args.out)
+            logging.info("Rendered alphabet from %d fonts", len(fonts))
+        else:
+            logging.warning("No fonts found matching %s; drop your pretty style fonts there", args.fonts)
+
+        if args.samples:
+            builder.ingest_samples(args.samples, args.out)
+            logging.info("Ingested real handwriting samples from %s", args.samples)
+
+        total = sum(class_counts(args.out).values())
+        logging.info("Dataset ready at %s with %d images across %d classes", args.out, total, len(DEFAULT_ALPHABET))
+
+    except Exception:
+        logging.exception("Process failed")
+
+
+if __name__ == "__main__":
+    _main()

--- a/call_ai_grapher/dataset/__init__.py
+++ b/call_ai_grapher/dataset/__init__.py
@@ -1,0 +1,20 @@
+"""Alphabet dataset generation and ingestion."""
+from call_ai_grapher.dataset.builder import (
+    AlphabetDatasetBuilder,
+    class_counts,
+    find_fonts,
+    normalize,
+    render_character,
+)
+from call_ai_grapher.dataset.charset import DEFAULT_ALPHABET, SPANISH_ALPHABET_LOWER, SPANISH_ALPHABET_UPPER
+
+__all__ = [
+    "AlphabetDatasetBuilder",
+    "class_counts",
+    "find_fonts",
+    "normalize",
+    "render_character",
+    "DEFAULT_ALPHABET",
+    "SPANISH_ALPHABET_LOWER",
+    "SPANISH_ALPHABET_UPPER",
+]

--- a/call_ai_grapher/dataset/builder.py
+++ b/call_ai_grapher/dataset/builder.py
@@ -1,0 +1,192 @@
+"""Alphabet dataset builder.
+
+Generates the reference alphabet ("pretty" handwriting) by rendering every
+character of the Spanish alphabet with TrueType fonts, and ingests real
+handwriting samples provided by the user. All images are normalized to a
+fixed size so later stages (classifier, stylizer) can consume them directly.
+"""
+import glob as _glob
+import logging
+from pathlib import Path
+from typing import Dict, Iterable, List, Optional, Union
+
+import cv2
+import numpy as np
+from PIL import Image, ImageDraw, ImageFont
+
+from call_ai_grapher.dataset.charset import DEFAULT_ALPHABET
+
+IMAGE_EXTENSION = ".png"
+
+
+class AlphabetDatasetBuilder:
+    def __init__(self, chars: str = DEFAULT_ALPHABET, size: int = 64):
+        """_summary_
+        :param chars: character classes of the dataset
+        :type chars: str
+        :param size: normalized image side in pixels
+        :type size: int
+        """
+        self.chars = chars
+        self.size = size
+
+    def build_from_fonts(
+        self, fonts: Iterable[Union[str, Path, ImageFont.FreeTypeFont]], out_dir: Union[str, Path]
+    ) -> Dict[str, int]:
+        """Render every character with every font into the dataset.
+
+        :param fonts: font file paths or already loaded fonts
+        :type fonts: Iterable[Union[str, Path, ImageFont.FreeTypeFont]]
+        :param out_dir: dataset root; images land in `out_dir/<char>/`
+        :type out_dir: Union[str, Path]
+        :return: number of images stored per class
+        :rtype: Dict[str, int]
+        """
+        counts: Dict[str, List[Path]] = {char: [] for char in self.chars}
+        for font in fonts:
+            if isinstance(font, ImageFont.FreeTypeFont):
+                name = "default"
+            else:
+                font_path = Path(font)
+                try:
+                    font = ImageFont.truetype(str(font_path), 96)
+                except OSError:
+                    logging.warning("Skipping unreadable font %s", font_path)
+                    continue
+                name = font_path.stem
+                name = font_path.stem
+            for char in self.chars:
+                rendered = render_character(char, font)
+                normalized = normalize(rendered, self.size)
+                file_name = f"{name}_{ord(char)}{IMAGE_EXTENSION}"
+                path = Path(out_dir) / char / file_name
+                path.parent.mkdir(parents=True, exist_ok=True)
+                _save(path, normalized)
+                counts[char].append(path)
+        return {char: len(paths) for char, paths in counts.items()}
+
+    def ingest_samples(self, samples_dir: Union[str, Path], out_dir: Union[str, Path]) -> Dict[str, int]:
+        """Ingest real handwriting crops organized as `samples_dir/<char>/*`.
+
+        Samples are normalized the same way as the rendered ones so both
+        sources are interchangeable for training.
+
+        :param samples_dir: directory with one subdirectory per class
+        :type samples_dir: Union[str, Path]
+        :param out_dir: dataset root; images land in `out_dir/<char>/`
+        :type out_dir: Union[str, Path]
+        :return: number of images stored per class
+        :rtype: Dict[str, int]
+        """
+        counts: Dict[str, List[Path]] = {char: [] for char in self.chars}
+        samples_dir = Path(samples_dir)
+        for class_dir in sorted(p for p in samples_dir.iterdir() if p.is_dir()):
+            char = class_dir.name
+            if char not in counts:
+                logging.warning("Ignoring unknown class directory %s", class_dir)
+                continue
+            for i, sample in enumerate(sorted(class_dir.glob("*"))):
+                image = cv2.imread(str(sample), cv2.IMREAD_GRAYSCALE)
+                if image is None:
+                    logging.warning("Skipping unreadable sample %s", sample)
+                    continue
+                normalized = normalize(image, self.size)
+                path = Path(out_dir) / char / f"sample_{i:04d}{IMAGE_EXTENSION}"
+                path.parent.mkdir(parents=True, exist_ok=True)
+                _save(path, normalized)
+                counts[char].append(path)
+        return {char: len(paths) for char, paths in counts.items()}
+
+
+def render_character(char: str, font: Union[str, Path, ImageFont.FreeTypeFont], padding: int = 8) -> Image.Image:
+    """Render a single character on a white canvas.
+
+    :param char: character to render
+    :type char: str
+    :param font: font file path or already loaded font
+    :type font: Union[str, Path, ImageFont.FreeTypeFont]
+    :param padding: white margin around the glyph
+    :type padding: int
+    :return: rendered character image
+    :rtype: Image.Image
+    """
+    if isinstance(font, (str, Path)):
+        font = ImageFont.truetype(str(font), 96)
+    probe = Image.new("L", (1, 1))
+    _, _, w, h = ImageDraw.Draw(probe).textbbox((0, 0), char, font=font)
+    image = Image.new("L", (w + padding * 2, h + padding * 2), color=255)
+    ImageDraw.Draw(image).text((padding, padding), char, fill=0, font=font)
+    return image
+
+
+def normalize(image: Union[np.ndarray, Image.Image], size: int, content_ratio: float = 0.8) -> np.ndarray:
+    """Normalize a character image to a fixed square canvas.
+
+    Steps: grayscale, Otsu binarization, crop to the ink bounding box,
+    scale keeping aspect ratio and center on a white canvas.
+
+    :param image: input character image
+    :type image: Union[np.ndarray, Image.Image]
+    :param size: output canvas side in pixels
+    :type size: int
+    :param content_ratio: fraction of the canvas the ink may span
+    :type content_ratio: float
+    :return: normalized grayscale image of shape (size, size)
+    :rtype: np.ndarray
+    """
+    if isinstance(image, Image.Image):
+        image = np.array(image)
+    gray = cv2.cvtColor(image, cv2.COLOR_BGR2GRAY) if image.ndim == 3 else image
+    _, binary = cv2.threshold(gray, 0, 255, cv2.THRESH_BINARY_INV + cv2.THRESH_OTSU)
+
+    ys, xs = np.nonzero(binary)
+    canvas = np.full((size, size), 255, dtype=np.uint8)
+    if len(xs) == 0:
+        return canvas
+
+    x0, x1 = xs.min(), xs.max() + 1
+    y0, y1 = ys.min(), ys.max() + 1
+    ink = gray[y0:y1, x0:x1]
+
+    target = int(size * content_ratio)
+    scale = target / max(ink.shape)
+    resized = cv2.resize(ink, (max(int(ink.shape[1] * scale), 1), max(int(ink.shape[0] * scale), 1)))
+
+    dy = (size - resized.shape[0]) // 2
+    dx = (size - resized.shape[1]) // 2
+    canvas[dy : dy + resized.shape[0], dx : dx + resized.shape[1]] = resized
+    return canvas
+
+
+def _save(path: Path, image: np.ndarray) -> None:
+    """Write a grayscale image to disk.
+
+    :param path: destination file path
+    :type path: Path
+    :param image: grayscale image
+    :type image: np.ndarray
+    """
+    Image.fromarray(image).save(path)
+
+
+def find_fonts(pattern: str = "fonts/**/*.ttf") -> List[Path]:
+    """Find font files matching a glob pattern.
+
+    :param pattern: glob pattern, relative or absolute
+    :type pattern: str
+    :return: sorted list of matching font paths
+    :rtype: List[Path]
+    """
+    return sorted(Path(p) for p in _glob.glob(pattern))
+
+
+def class_counts(dataset_dir: Union[str, Path]) -> Dict[str, int]:
+    """Count the images stored per class directory.
+
+    :param dataset_dir: dataset root containing one directory per class
+    :type dataset_dir: Union[str, Path]
+    :return: mapping class -> number of images
+    :rtype: Dict[str, int]
+    """
+    root = Path(dataset_dir)
+    return {d.name: len(list(d.glob(f"*{IMAGE_EXTENSION}"))) for d in sorted(root.iterdir()) if d.is_dir()}

--- a/call_ai_grapher/dataset/charset.py
+++ b/call_ai_grapher/dataset/charset.py
@@ -1,0 +1,10 @@
+"""Character sets supported by the handwriting improvement pipeline."""
+
+SPANISH_ALPHABET_UPPER = "ABCDEFGHIJKLMNÑOPQRSTUVWXYZ"
+"""Uppercase Spanish alphabet: 27 classes including Ñ."""
+
+SPANISH_ALPHABET_LOWER = "abcdefghijklmnñopqrstuvwxyz"
+"""Lowercase Spanish alphabet: 27 classes including ñ."""
+
+DEFAULT_ALPHABET = SPANISH_ALPHABET_UPPER
+"""Default character set used when building the alphabet dataset."""

--- a/tests/test_dataset_builder.py
+++ b/tests/test_dataset_builder.py
@@ -1,0 +1,87 @@
+import numpy as np
+
+from call_ai_grapher.dataset import (
+    DEFAULT_ALPHABET,
+    SPANISH_ALPHABET_LOWER,
+    SPANISH_ALPHABET_UPPER,
+    AlphabetDatasetBuilder,
+    normalize,
+    render_character,
+)
+
+
+def test_spanish_alphabets_have_27_classes_with_enye():
+    assert len(SPANISH_ALPHABET_UPPER) == 27
+    assert "Ñ" in SPANISH_ALPHABET_UPPER
+    assert len(SPANISH_ALPHABET_LOWER) == 27
+    assert "ñ" in SPANISH_ALPHABET_LOWER
+    assert DEFAULT_ALPHABET == SPANISH_ALPHABET_UPPER
+
+
+def test_render_character_produces_ink():
+    from PIL import ImageFont
+
+    font = ImageFont.load_default(size=48)
+    image = render_character("A", font)
+    arr = np.array(image)
+    assert image.mode == "L"
+    assert (arr < 128).sum() > 0
+
+
+def test_normalize_returns_square_centered_canvas():
+    image = np.full((40, 90), 255, dtype=np.uint8)
+    image[10:30, 20:70] = 0
+    normalized = normalize(image, size=64)
+    assert normalized.shape == (64, 64)
+
+    ys, xs = np.nonzero(normalized < 128)
+    center_x = (xs.min() + xs.max()) / 2
+    center_y = (ys.min() + ys.max()) / 2
+    assert abs(center_x - 31.5) < 3
+    assert abs(center_y - 31.5) < 3
+
+
+def test_normalize_empty_image_returns_white_canvas():
+    image = np.full((32, 32), 255, dtype=np.uint8)
+    normalized = normalize(image, size=64)
+    assert normalized.shape == (64, 64)
+    assert (normalized == 255).all()
+
+
+def test_build_from_fonts_creates_class_directories(tmp_path):
+    from PIL import ImageFont
+
+    font = ImageFont.load_default(size=48)
+    builder = AlphabetDatasetBuilder(size=64)
+    counts = builder.build_from_fonts([font], tmp_path)
+
+    assert len(counts) == 27
+    assert all(count == 1 for count in counts.values())
+    assert (tmp_path / "Ñ").is_dir()
+    assert list((tmp_path / "A").glob("*.png"))
+
+
+def test_ingest_samples_normalizes_and_stores(tmp_path):
+    from PIL import Image
+
+    samples = tmp_path / "samples" / "B"
+    samples.mkdir(parents=True)
+    for i, width in enumerate((20, 35)):
+        image = np.full((50, width), 255, dtype=np.uint8)
+        image[15:35, 5 : width - 5] = 0
+        Image.fromarray(image).save(samples / f"{i}.png")
+
+    builder = AlphabetDatasetBuilder(size=64)
+    counts = builder.ingest_samples(tmp_path / "samples", tmp_path / "dataset")
+
+    assert counts["B"] == 2
+    first_stored = sorted((tmp_path / "dataset" / "B").glob("*.png"))[0]
+    assert np.array(Image.open(first_stored)).shape == (64, 64)
+
+
+def test_ingest_samples_ignores_unknown_classes(tmp_path):
+    unknown = tmp_path / "samples" / "1"
+    unknown.mkdir(parents=True)
+    builder = AlphabetDatasetBuilder(size=64)
+    counts = builder.ingest_samples(tmp_path / "samples", tmp_path / "dataset")
+    assert sum(counts.values()) == 0


### PR DESCRIPTION
## Summary
Second milestone of the roadmap: a dataset builder that generates the Spanish alphabet reference (A-Z + Ñ, 27 classes) from TrueType fonts and ingests the user's real handwriting crops, producing normalized 64x64 images ready for the classifier and stylizer stages.

## What Changed
- Added `call_ai_grapher/dataset/` package:
  - `charset.py`: `SPANISH_ALPHABET_UPPER` / `SPANISH_ALPHABET_LOWER` (27 classes each, Ñ/ñ included), `DEFAULT_ALPHABET`.
  - `builder.py`:
    - `AlphabetDatasetBuilder.build_from_fonts()` renders every character with every font into `out_dir/<char>/`.
    - `AlphabetDatasetBuilder.ingest_samples()` ingests real handwriting crops organized as `samples_dir/<class>/*`, ignoring unknown classes.
    - `normalize()`: grayscale → Otsu binarization → ink bounding-box crop → aspect-preserving scale (80% of canvas) → centered on white canvas.
    - `render_character()`, `find_fonts()` (relative or absolute globs), `class_counts()`.
- Added `build_alphabet.py` CLI: `--fonts`, `--samples`, `--out`, `--size`.
- Updated `README.md` roadmap and usage instructions.

## Testing
- `.venv/bin/python -m pytest tests/ -q`: 17 passed (7 new: charset, rendering, normalization centering/empty input, font building, sample ingestion, unknown-class handling).
- End-to-end smoke with two system fonts (`Comic Sans MS`, `Bradley Hand Bold`): `python build_alphabet.py --fonts ... --out ... --size 64` produced 54 images across 27 classes; verified `Ñ` images are 64x64, binarized and centered.

## Breaking Changes
None