### PR TITLE
Add CNN character classifier for A-Z + Ñ

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Pipeline: `scanned page -> character detection -> character classification -> pe
 | Pipeline skeleton (types, stages, orchestrator, CLI) | ✅ | `ft/pipeline-skeleton` |
 | Spanish alphabet dataset builder (A-Z + ñ, TTF + real samples) | ✅ | `ft/alphabet-dataset` |
 | Character detector (YOLOv8, MSER fallback) | ✅ | `ft/char-detector` |
-| Character classifier (CNN) | ⬜ | `ft/char-classifier` |
+| Character classifier (CNN) | ✅ | `ft/char-classifier` |
 | Per-character style transfer (pix2pix / latent AE) | ⬜ | `ft/style-stylizer` |
 | Blend regulator (latent interpolation alpha) | ⬜ | `ft/blend-regulator` |
 | Document recomposer (baseline alignment) | ⬜ | `ft/document-recomposer` |
@@ -60,6 +60,26 @@ needed.
    ```
    python improve_document.py --input documents/page.jpeg --output documents/improved.png \
        --alpha 0.8 --detector yolo --model models/character_detector.pt --confidence 0.25
+   ```
+
+### Character classification (A-Z + Ñ)
+
+A small CNN (`CharCNN`, ~300k parameters) labels every detected character
+crop using the alphabet dataset from `build_alphabet.py`. It reads the same
+normalized images, so fonts and your real handwriting samples are both used
+automatically.
+
+1. Train on the alphabet dataset (seconds on CPU; reference: 83% accuracy
+   over 27 classes with only 2 fonts — add more fonts and real samples in
+   `--samples` to improve it):
+   ```
+   python train_classifier.py --data dataset/alphabet --out models/char_classifier.pt --epochs 40
+   ```
+
+2. Pass the checkpoint to the pipeline to label characters:
+   ```
+   python improve_document.py --input documents/page.jpeg --output documents/improved.png \
+       --alpha 0.8 --detector yolo --classifier models/char_classifier.pt
    ```
 
 ## Experiments

--- a/call_ai_grapher/pipeline/classifier.py
+++ b/call_ai_grapher/pipeline/classifier.py
@@ -1,18 +1,28 @@
 """Character classification stage.
 
-Assigns a label (A-Z plus ñ) and a confidence to each detected character
-crop. Backed by a small CNN trained on the alphabet dataset built by
-build_alphabet.py (see ft/char-classifier).
+Assigns a label (A-Z plus Ñ) and a confidence to each detected character
+crop using the CharCNN trained by `train_classifier.py` on the alphabet
+dataset built by `build_alphabet.py`.
 """
 import logging
 from typing import List, Tuple
 
 import numpy as np
+import torch
 
+from call_ai_grapher.dataset.builder import normalize
+from call_ai_grapher.models.char_cnn import CharCNN, load_checkpoint
 from call_ai_grapher.pipeline.types import CharBox
 
 
 class CharClassifier:
+    def __init__(self, model_path: str = "models/char_classifier.pt"):
+        """_summary_
+        :param model_path: path to the checkpoint written by train_classifier.py
+        :type model_path: str
+        """
+        self.model, self.classes = load_checkpoint(model_path)
+
     def classify(self, page: np.ndarray, boxes: List[CharBox]) -> List[CharBox]:
         """Fill in `label` and `confidence` for each box, in place.
 
@@ -23,14 +33,27 @@ class CharClassifier:
         :return: the same boxes with labels assigned
         :rtype: List[CharBox]
         """
-        raise NotImplementedError("CharClassifier is implemented in ft/char-classifier")
+        for box in boxes:
+            label, confidence = self.classify_crop(box.crop_from(page))
+            box.label = label
+            box.confidence = confidence
+        logging.info("Classified %d characters", len(boxes))
+        return boxes
 
     def classify_crop(self, crop: np.ndarray) -> Tuple[str, float]:
         """Classify a single character crop.
 
-        :param crop: grayscale character image
+        The crop is normalized exactly like the training data, so raw
+        detections from any detector are handled uniformly.
+
+        :param crop: character image (grayscale or BGR)
         :type crop: np.ndarray
         :return: (label, confidence)
         :rtype: Tuple[str, float]
         """
-        raise NotImplementedError("CharClassifier is implemented in ft/char-classifier")
+        image = normalize(crop, self.model.size).astype(np.float32) / 255.0
+        tensor = torch.from_numpy(image).unsqueeze(0).unsqueeze(0)
+        with torch.no_grad():
+            probabilities = torch.softmax(self.model(tensor), dim=1)[0]
+        confidence, index = probabilities.max(0)
+        return self.classes[int(index)], float(confidence)

--- a/improve_document.py
+++ b/improve_document.py
@@ -14,6 +14,14 @@ def _build_detector(args):
     return CharacterDetector()
 
 
+def _build_classifier(args):
+    if not args.classifier:
+        return None
+    from call_ai_grapher.pipeline.classifier import CharClassifier
+
+    return CharClassifier(args.classifier)
+
+
 def _parse_args():
     parser = argparse.ArgumentParser(description="Improve the handwriting of a scanned document")
     parser.add_argument("--input", required=True, help="path to the scanned page image")
@@ -22,6 +30,7 @@ def _parse_args():
     parser.add_argument("--detector", choices=["mser", "yolo"], default="mser", help="character detection backend")
     parser.add_argument("--model", default="models/character_detector.pt", help="YOLO weights path (--detector yolo)")
     parser.add_argument("--confidence", type=float, default=0.25, help="minimum detection confidence (--detector yolo)")
+    parser.add_argument("--classifier", default=None, help="classifier checkpoint to label characters (optional)")
     return parser.parse_args()
 
 
@@ -29,7 +38,7 @@ def _main():
     try:
         logging.basicConfig(format="%(asctime)-15s %(levelname)s %(message)s", level=logging.INFO)
         args = _parse_args()
-        grapher = CallAIgraher(detector=_build_detector(args))
+        grapher = CallAIgraher(detector=_build_detector(args), classifier=_build_classifier(args))
         result = grapher.improve_document(args.input, args.output, args.alpha)
         logging.info(
             "Done: %d characters processed, output at %s",

--- a/tests/test_char_classifier.py
+++ b/tests/test_char_classifier.py
@@ -1,0 +1,92 @@
+import numpy as np
+import pytest
+import torch
+
+from call_ai_grapher.models import CharCNN, load_checkpoint, save_checkpoint, train_model
+from call_ai_grapher.pipeline.classifier import CharClassifier
+from call_ai_grapher.pipeline.types import CharBox
+
+
+@pytest.fixture(scope="module")
+def alphabet_dir(tmp_path_factory):
+    """A tiny 3-class alphabet dataset with easily separable glyphs."""
+    import cv2
+
+    root = tmp_path_factory.mktemp("alphabet")
+    for char in ("A", "B", "Ñ"):
+        class_dir = root / char
+        class_dir.mkdir()
+        for i in range(4):
+            glyph = np.full((64, 64), 255, dtype=np.uint8)
+            if char == "A":
+                cv2.circle(glyph, (32, 32), 14 + i, 0, -1)
+            elif char == "B":
+                cv2.line(glyph, (32, 10), (32, 54), 0, 4 + i)
+            else:
+                cv2.line(glyph, (12, 12), (52, 52), 0, 4 + i)
+            cv2.imwrite(str(class_dir / f"g{i}.png"), glyph)
+    return root
+
+
+def test_char_cnn_forward_shape():
+    model = CharCNN(num_classes=27)
+    out = model(torch.rand(4, 1, 64, 64))
+    assert out.shape == (4, 27)
+
+
+def test_train_model_reaches_perfect_accuracy_on_synthetic(alphabet_dir, tmp_path):
+    metrics = train_model(alphabet_dir, tmp_path / "classifier.pt", epochs=30, seed=0)
+    assert metrics["accuracy"] > 0.9
+
+
+def test_checkpoint_roundtrip(alphabet_dir, tmp_path):
+    train_model(alphabet_dir, tmp_path / "classifier.pt", epochs=1, seed=0)
+    model, classes = load_checkpoint(tmp_path / "classifier.pt")
+    assert classes == ["A", "B", "Ñ"]
+    assert not model.training
+
+
+def test_classifier_labels_boxes(alphabet_dir, tmp_path):
+    train_model(alphabet_dir, tmp_path / "classifier.pt", epochs=30, seed=0)
+
+    import cv2
+
+    page = np.full((100, 200), 255, dtype=np.uint8)
+    glyph = cv2.imread(str(alphabet_dir / "A" / "g0.png"), cv2.IMREAD_GRAYSCALE)
+    page[10:74, 20:84] = glyph
+    boxes = [CharBox(x=20, y=10, width=64, height=64)]
+
+    classifier = CharClassifier(str(tmp_path / "classifier.pt"))
+    labeled = classifier.classify(page, boxes)
+
+    assert labeled[0].label == "A"
+    assert labeled[0].confidence > 0.5
+
+
+def test_classify_crop_returns_valid_label_and_confidence(tmp_path):
+    classifier = CharClassifier(_train_mini(tmp_path))
+    label, confidence = classifier.classify_crop(np.full((32, 32), 255, dtype=np.uint8))
+    assert label in ("A", "B", "Ñ")
+    assert 0.0 <= confidence <= 1.0
+
+
+def _mini_dataset(root):
+    import cv2
+
+    data_dir = root / "mini"
+    for char in ("A", "B", "Ñ"):
+        class_dir = data_dir / char
+        class_dir.mkdir(parents=True)
+        for i in range(2):
+            glyph = np.full((64, 64), 255, dtype=np.uint8)
+            cv2.rectangle(glyph, (12 + i, 12 + i), (50, 50), 0, 2)
+            cv2.imwrite(str(class_dir / f"g{i}.png"), glyph)
+    return str(data_dir)
+
+
+def _train_mini(root):
+    from call_ai_grapher.models import train_model
+
+    checkpoint = root / "mini.pt"
+    train_model(_mini_dataset(root), checkpoint, epochs=1, seed=0)
+    return str(checkpoint)

--- a/train_classifier.py
+++ b/train_classifier.py
@@ -1,0 +1,31 @@
+import argparse
+import logging
+
+from call_ai_grapher.models import train_model
+
+
+def _parse_args():
+    parser = argparse.ArgumentParser(description="Train the character classifier (A-Z + Ñ)")
+    parser.add_argument("--data", default="dataset/alphabet", help="alphabet dataset directory (one dir per class)")
+    parser.add_argument("--out", default="models/char_classifier.pt", help="where to write the checkpoint")
+    parser.add_argument("--epochs", type=int, default=40, help="number of training epochs")
+    parser.add_argument("--batch-size", type=int, default=32, help="images per optimization step")
+    parser.add_argument("--lr", type=float, default=1e-3, help="learning rate")
+    parser.add_argument("--seed", type=int, default=0, help="random seed")
+    return parser.parse_args()
+
+
+def _main():
+    try:
+        logging.basicConfig(format="%(asctime)-15s %(levelname)s %(message)s", level=logging.INFO)
+        args = _parse_args()
+        metrics = train_model(
+            args.data, args.out, epochs=args.epochs, batch_size=args.batch_size, lr=args.lr, seed=args.seed
+        )
+        logging.info("Done: final loss %.4f, accuracy %.3f", metrics["loss"], metrics["accuracy"])
+    except Exception:
+        logging.exception("Process failed")
+
+
+if __name__ == "__main__":
+    _main()


### PR DESCRIPTION
## Summary
Fourth roadmap milestone: a CNN character classifier that labels every detected crop with its character (A-Z + Ñ) and confidence, replacing the `CharClassifier` stub from the pipeline skeleton. It trains on the same normalized alphabet dataset as everything else, so font renders and real handwriting samples are used automatically.

## What Changed
- Added `call_ai_grapher/models/` package:
  - `char_cnn.py`: `CharCNN` (~300k params: 3 conv blocks + FC head), checkpoint save/load (weights + class mapping + input size), dataset loader reusing `normalize()` from the dataset builder, random affine augmentation (±10° rotation, 0.85-1.15 scale, ±8% translation), and `train_model()` returning final loss/accuracy.
- Implemented `call_ai_grapher/pipeline/classifier.py`: `CharClassifier(model_path)` with `classify_crop(crop) -> (label, confidence)` and `classify(page, boxes)` filling labels in place; crops are normalized exactly like training data.
- Added `train_classifier.py` CLI (`--data/--out/--epochs/--batch-size/--lr/--seed`).
- `improve_document.py` now accepts `--classifier models/char_classifier.pt` to label characters during the run; classification stays optional.
- README: classifier training/usage section and roadmap updated.

## Testing
- `.venv/bin/python -m pytest tests/ -q`: 26 passed (5 new: CNN output shape, training convergence on synthetic glyphs, checkpoint round-trip, box labeling end-to-end, crop classification bounds).
- Trained on the real alphabet dataset (2 fonts × 27 chars): 83% accuracy in 40 epochs (~7s CPU); documented that more fonts/samples improve it.

## Breaking Changes
None