### PR TITLE
Align recomposed characters by baseline

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,9 @@ Pipeline: `scanned page -> character detection -> character classification -> pe
 | Character classifier (CNN) | ✅ | `ft/char-classifier` |
 | Per-character style transfer (pix2pix) | ✅ | `ft/style-stylizer` |
 | Latent-space blend regulator | ✅ | `ft/blend-regulator` |
-| Per-character style transfer (pix2pix / latent AE) | ⬜ | `ft/style-stylizer` |
-| Blend regulator (latent interpolation alpha) | ⬜ | `ft/blend-regulator` |
-| Document recomposer (baseline alignment) | ⬜ | `ft/document-recomposer` |
+| Per-character style transfer (pix2pix / latent AE) | ✅ | `ft/style-stylizer` |
+| Blend regulator (latent interpolation alpha) | ✅ | `ft/blend-regulator` |
+| Document recomposer (baseline alignment) | ✅ | `ft/document-recomposer` |
 | Gradio app (upload, slider, before/after) | ✅ | `ft/web-ui` |
 
 Run the pipeline today (MSER detection + baseline cleanup stylizer):

--- a/call_ai_grapher/pipeline/recomposer.py
+++ b/call_ai_grapher/pipeline/recomposer.py
@@ -1,21 +1,26 @@
 """Document recomposition stage.
 
 Pastes the styled characters back into the page at their original positions,
-preserving line layout and baseline alignment (see ft/document-recomposer).
+aligning replacements vertically by character baseline so strokes sit on the
+same line instead of floating inside their bounding boxes (see
+ft/document-recomposer).
 """
 import logging
-from typing import List
+from typing import List, Optional
 
 import numpy as np
 
-from call_ai_grapher.pipeline.types import StyledChar
+from call_ai_grapher.pipeline.types import CharBox, StyledChar
 
 
 class Recomposer:
     def compose(self, page: np.ndarray, chars: List[StyledChar]) -> np.ndarray:
         """Return a new page where every styled character replaces its original.
 
-        Characters without a styled replacement are left untouched.
+        Characters without a styled replacement are left untouched. When both
+        the original crop and its replacement have detectable ink, the patch
+        is shifted vertically so both baselines coincide; otherwise the patch
+        simply fills the original box.
 
         :param page: original page image
         :type page: np.ndarray
@@ -36,10 +41,71 @@ class Recomposer:
             elif patch.ndim == 3 and result.ndim == 2:
                 result = np.stack((result,) * 3, axis=-1)
             region = result[box.y : box.y2, box.x : box.x2]
-            result[box.y : box.y2, box.x : box.x2] = _fit(patch, region.shape)
+            patch = _fit(patch, region.shape)
+
+            src_baseline = box.baseline if box.baseline is not None else estimate_baseline(char.original)
+            dst_baseline = estimate_baseline(patch)
+            if box.baseline is None:
+                box.baseline = src_baseline
+
+            if src_baseline is None or dst_baseline is None:
+                result[box.y : box.y2, box.x : box.x2] = patch
+            else:
+                _paste_aligned(result, patch, box, src_baseline - dst_baseline)
             replaced += 1
         logging.info("Replaced %d of %d characters", replaced, len(chars))
         return result
+
+
+def estimate_baseline(crop: np.ndarray) -> Optional[int]:
+    """Return the row index of the lowest ink pixel inside `crop`.
+
+    Ink is separated with an Otsu threshold after removing speckle noise, so
+    scans with uneven lighting are handled. Crops without a clear foreground
+    (blank patches or uniform regions) have no measurable baseline.
+
+    :param crop: character image, grayscale or BGR
+    :type crop: np.ndarray
+    :return: baseline row index, or None when no ink is detected
+    :rtype: Optional[int]
+    """
+    import cv2
+
+    gray = cv2.cvtColor(crop, cv2.COLOR_BGR2GRAY) if crop.ndim == 3 else crop
+    if gray.size == 0 or int(gray.std()) < 2:
+        return None
+    _, binary = cv2.threshold(gray, 0, 255, cv2.THRESH_BINARY_INV + cv2.THRESH_OTSU)
+    binary = cv2.medianBlur(binary, 3)
+    rows = np.where(binary.any(axis=1))[0]
+    return int(rows[-1]) if len(rows) else None
+
+
+def _paste_aligned(page: np.ndarray, patch: np.ndarray, box: CharBox, shift: int) -> None:
+    """Clear `box` on `page` and paste `patch` shifted vertically by `shift`.
+
+    Rows pushed outside the page are clipped. The exposed area is filled with
+    the local background estimated from the original box pixels.
+
+    :param page: page being recomposed, modified in place
+    :type page: np.ndarray
+    :param patch: styled patch already sized to the box
+    :type patch: np.ndarray
+    :param box: source box of the character being replaced
+    :type box: CharBox
+    :param shift: vertical offset applied to the patch, positive moves down
+    :type shift: int
+    """
+    region = page[box.y : box.y2, box.x : box.x2]
+    background = np.median(region, axis=(0, 1)).astype(page.dtype)
+    page[box.y : box.y2, box.x : box.x2] = background
+
+    height = patch.shape[0]
+    src_start = max(0, -(box.y + shift))
+    src_end = height - max(0, box.y + shift + height - page.shape[0])
+    if src_end <= src_start:
+        page[box.y : box.y2, box.x : box.x2] = patch
+        return
+    page[box.y + shift + src_start : box.y + shift + src_end, box.x : box.x2] = patch[src_start:src_end]
 
 
 def _fit(patch: np.ndarray, shape: tuple) -> np.ndarray:

--- a/tests/test_recomposer.py
+++ b/tests/test_recomposer.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from call_ai_grapher.pipeline.recomposer import Recomposer
+from call_ai_grapher.pipeline.recomposer import Recomposer, estimate_baseline
 from call_ai_grapher.pipeline.types import CharBox, StyledChar
 
 
@@ -30,3 +30,51 @@ def test_compose_resizes_mismatched_patch():
     styled = np.zeros((5, 5), dtype=np.uint8)
     result = Recomposer().compose(page, [StyledChar(box=box, original=page[0:10, 0:10], styled=styled)])
     assert (result[0:10, 0:10] == 0).all()
+
+
+def test_estimate_baseline_returns_lowest_ink_row():
+    crop = np.full((20, 20), 255, dtype=np.uint8)
+    crop[5:13, 6:14] = 0
+    assert estimate_baseline(crop) == 12
+
+
+def test_estimate_baseline_blank_crop_returns_none():
+    assert estimate_baseline(np.full((20, 20), 255, dtype=np.uint8)) is None
+
+
+def test_compose_aligns_replacement_to_source_baseline():
+    page = _page()
+    box = CharBox(x=10, y=10, width=20, height=20)
+    original = np.full((20, 20), 255, dtype=np.uint8)
+    original[2:7, 6:14] = 0
+    styled = np.full((20, 20), 255, dtype=np.uint8)
+    styled[8:17, 6:14] = 0
+
+    result = Recomposer().compose(page, [StyledChar(box=box, original=original, styled=styled)])
+
+    assert (result[16, 16:24] < 50).all()
+    assert (result[24:27, 16:24] > 200).all()
+
+
+def test_compose_records_estimated_baseline_in_box():
+    page = _page()
+    box = CharBox(x=10, y=10, width=20, height=20)
+    original = np.full((20, 20), 255, dtype=np.uint8)
+    original[2:7, 6:14] = 0
+    styled = np.zeros((20, 20), dtype=np.uint8)
+
+    Recomposer().compose(page, [StyledChar(box=box, original=original, styled=styled)])
+
+    assert box.baseline == 6
+
+
+def test_compose_falls_back_when_source_has_no_ink():
+    page = _page()
+    box = CharBox(x=10, y=10, width=20, height=20)
+    original = np.full((20, 20), 255, dtype=np.uint8)
+    styled = np.full((20, 20), 255, dtype=np.uint8)
+    styled[0:5, 6:14] = 0
+
+    result = Recomposer().compose(page, [StyledChar(box=box, original=original, styled=styled)])
+
+    assert (result[10:15, 16:24] < 50).all()


### PR DESCRIPTION
## Summary
Implements baseline alignment in the document recomposer, completing the last roadmap milestone with real pending work and closing out the roadmap table.

## What Changed
- Added `estimate_baseline()` in `call_ai_grapher/pipeline/recomposer.py`: finds the lowest ink row of a crop via Otsu thresholding plus median-blur speckle removal; returns `None` for blank or uniform crops.
- `Recomposer.compose()` now aligns replacements vertically by baseline: it takes `CharBox.baseline` when available, otherwise estimates it from the original crop and records it back on the box (the field documented in `pipeline/types.py` finally gets populated). When both baselines are measurable, the styled patch is shifted so both coincide; exposed areas are filled with locally estimated background.
- Added `_paste_aligned()` helper: clears the source box, pastes the shifted patch clipped to the page bounds, and falls back to the previous plain paste when no ink is measurable on either side.
- Added 5 tests in `tests/test_recomposer.py` (ink-bottom estimation, blank-crop case, píxel-level alignment assertion, baseline recording on the box, fallback without ink); existing 3 tests unchanged and passing.
- Flipped the three remaining roadmap rows in `README.md` to done: pix2pix/latent AE stylizer and latent blend regulator were already delivered (PRs #29/#30, stale placeholder rows); document recomposer is delivered by this change.

## Testing
- `uv run pytest -q` → 47 passed.
- `pre-commit run --all-files` → all hooks pass.

## Breaking Changes
- None. Without measurable ink the recomposer behaves exactly as before.