### PR TITLE
Reorder README for step-by-step onboarding and log MSER max_area TODO

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
-# Introduction
-Improve handwriting using GANS
+# Call AI Grapher
+
+Improve handwriting using GANS.
 
 ## Roadmap
 
@@ -13,20 +14,54 @@ Pipeline: `scanned page -> character detection -> character classification -> pe
 | Spanish alphabet dataset builder (A-Z + ñ, TTF + real samples) | ✅ | `ft/alphabet-dataset` |
 | Character detector (YOLOv8, MSER fallback) | ✅ | `ft/char-detector` |
 | Character classifier (CNN) | ✅ | `ft/char-classifier` |
-| Per-character style transfer (pix2pix) | ✅ | `ft/style-stylizer` |
-| Latent-space blend regulator | ✅ | `ft/blend-regulator` |
 | Per-character style transfer (pix2pix / latent AE) | ✅ | `ft/style-stylizer` |
 | Blend regulator (latent interpolation alpha) | ✅ | `ft/blend-regulator` |
 | Document recomposer (baseline alignment) | ✅ | `ft/document-recomposer` |
 | Gradio app (upload, slider, before/after) | ✅ | `ft/web-ui` |
 
-Run the pipeline today (MSER detection + baseline cleanup stylizer):
+# Getting started
+
+## 1. Installation
+
+Install [uv](https://docs.astral.sh/uv/getting-started/installation/), then install all the dependencies. This also creates the virtual environment (`.venv`) if it didn't exist yet:
+
+```
+uv sync --all-groups
+```
+
+_If the installation fails you are probably missing the required Python version. uv installs it automatically. Depending on your internet connection and your machine the installation can take a few minutes._
+
+Install the pre-commit hooks:
+
+```
+uv run pre-commit install
+```
+
+## 2. Quick start (no training needed)
+
+The easiest way in is the local web app. Upload a scanned page and use the improvement slider to compare before/after:
+
+```
+uv run ui
+```
+
+Then open the URL printed in the terminal (http://127.0.0.1:7860 by default).
+
+Prefer the command line? Run the pipeline directly (MSER detection + baseline cleanup stylizer out of the box):
 
 ```
 uv run improve-document --input documents/page.jpeg --output documents/improved.png --alpha 0.8
 ```
 
-Build the alphabet dataset (drop your pretty style `.ttf` fonts into `fonts/` first):
+Everything below is optional: each step trains one model that makes the result better, and every step tells you exactly how to plug it into the command above.
+
+# Training your own models
+
+Follow these steps in order; each one builds on the previous and ends with the `improve-document` flags that activate it.
+
+## Step 1. Alphabet dataset
+
+Build the alphabet glyphs every other model trains on. Drop your pretty style `.ttf` fonts into `fonts/` first:
 
 ```
 uv run build-alphabet --fonts "fonts/**/*.ttf" --out dataset/alphabet --size 64
@@ -34,57 +69,61 @@ uv run build-alphabet --fonts "fonts/**/*.ttf" --out dataset/alphabet --size 64
 
 Ingest your own handwriting crops later with `--samples samples/`, where `samples/` contains one directory per character class.
 
-### Character detection with YOLOv8
+## Step 2. Character detection (YOLOv8)
 
 The detector locates characters on a scanned page (single class: `character`);
-labeling each one is the classifier's job (next milestone). Training data is
+labeling each one is the classifier's job (next step). Training data is
 generated synthetically from the alphabet glyphs, so no manual annotation is
 needed.
 
-1. Build the alphabet glyphs (previous step, `dataset/alphabet`).
+1. Generate synthetic training pages from the alphabet glyphs (scan-like degradation included):
 
-2. Generate synthetic training pages (scan-like degradation included):
    ```
    uv run generate-detector-dataset --glyphs dataset/alphabet --out dataset/detector --train-pages 500 --val-pages 100
    ```
 
-3. Train the detector. Reference run on CPU: 5 epochs over 80 pages took ~1 min
+2. Train the detector. Reference run on CPU: 5 epochs over 80 pages took ~1 min
    and already reached `mAP50 = 0.78`, `recall = 0.96`; expect near-perfect
    boxes with the settings below (~30-60 min on a modern laptop CPU):
+
    ```
    uv run train-detector --data dataset/detector/data.yaml --epochs 100 --imgsz 480 --out models/character_detector.pt
    ```
+
    Best weights are copied to `models/character_detector.pt`. Training curves
    land in `runs/detect/` (open with `tensorboard --logdir runs`).
 
-4. Run the pipeline with the trained detector (`--detector mser` is the
+3. Run the pipeline with the trained detector (`--detector mser` is the
    default fallback when no model is trained yet):
+
    ```
    uv run improve-document --input documents/page.jpeg --output documents/improved.png \
        --alpha 0.8 --detector yolo --model models/character_detector.pt --confidence 0.25
    ```
 
-### Character classification (A-Z + Ñ)
+## Step 3. Character classification (A-Z + Ñ)
 
 A small CNN (`CharCNN`, ~300k parameters) labels every detected character
-crop using the alphabet dataset from `build_alphabet.py`. It reads the same
+crop using the alphabet dataset from `build-alphabet`. It reads the same
 normalized images, so fonts and your real handwriting samples are both used
 automatically.
 
 1. Train on the alphabet dataset (seconds on CPU; reference: 83% accuracy
    over 27 classes with only 2 fonts — add more fonts and real samples in
    `--samples` to improve it):
+
    ```
    uv run train-classifier --data dataset/alphabet --out models/char_classifier.pt --epochs 40
    ```
 
 2. Pass the checkpoint to the pipeline to label characters:
+
    ```
    uv run improve-document --input documents/page.jpeg --output documents/improved.png \
        --alpha 0.8 --detector yolo --classifier models/char_classifier.pt
    ```
 
-### Style transfer (ugly -> pretty, pix2pix)
+## Step 4. Style transfer (ugly -> pretty, pix2pix)
 
 A conditional GAN (`UNetGenerator` + `PatchDiscriminator`, pix2pix recipe)
 learns to translate your poor handwriting towards the pretty style. One
@@ -98,6 +137,7 @@ sides of every pair are pixel-aligned without manual annotation.
 
 1. Train on the alphabet dataset (~2 min CPU for 15 epochs; L1 drops from
    0.40 to 0.03 meaning the generator reproduces the pretty style):
+
    ```
    uv run train-stylizer --data dataset/alphabet --out models/char_stylizer.pt --epochs 30
    ```
@@ -105,15 +145,17 @@ sides of every pair are pixel-aligned without manual annotation.
 2. Run the pipeline with neural stylization. The regulator `--alpha` becomes
    a cross-fade between your original stroke (0) and the full pretty style
    (1):
+
    ```
    uv run improve-document --input documents/page.jpeg --output documents/improved.png \
        --alpha 0.7 --detector yolo --classifier models/char_classifier.pt \
        --stylizer neural --stylizer-model models/char_stylizer.pt
    ```
+
    With `--stylizer baseline` (default) the regulator blends against a simple
    binarized cleanup instead, useful when no model is trained yet.
 
-### Latent blend regulator (no ghosting at mid alphas)
+## Step 5. Latent blend regulator (no ghosting at mid alphas)
 
 The pixel cross-fade above doubles the exposure at mid alphas (both strokes
 show through). The latent backend fixes this: a convolutional autoencoder —
@@ -125,36 +167,80 @@ dataset using the classifier label.
 
 1. Train the autoencoder (~30 s CPU for 20 epochs; reconstruction L1 drops
    from 0.37 to 0.04):
+
    ```
    uv run train-autoencoder --data dataset/alphabet --out models/char_autoencoder.pt --epochs 30
    ```
 
 2. Run the pipeline with latent stylization. This backend requires the
    classifier so each character finds its reference glyph:
+
    ```
    uv run improve-document --input documents/page.jpeg --output documents/improved.png \
        --alpha 0.5 --detector yolo --classifier models/char_classifier.pt \
        --stylizer latent --ae-model models/char_autoencoder.pt --alphabet-dir dataset/alphabet
    ```
 
-### Web UI (Gradio)
+The web app mirrors all of this: its "Backends" panel exposes the same options
+as the CLI flags (detector `mser`/`yolo` with weights path and confidence,
+optional classifier checkpoint, and stylizer `baseline`/`neural`/`latent` with
+its model paths and the alphabet dataset).
 
-The same pipeline behind `improve_document.py` is available as a local web
-app. Upload a scanned page and the app detects and labels every character
-once; the improvement slider then re-stylizes the page instantly, comparing
-the original document (before) against the improved one (after).
+# Project structure
 
+The repository is a [uv workspace](https://docs.astral.sh/uv/concepts/workspaces/) split into backend and frontend:
+
+```bash
+.
+├── pyproject.toml            # workspace root + shared tooling config
+├── assets/                   # gifs, handwriting samples and base weights
+├── backend/
+│   ├── pyproject.toml        # call-ai-grapher package + CLI entry points
+│   ├── experiments/          # early GAN/denoising experiment scripts
+│   └── src/call_ai_grapher/  # pipeline, models, dataset, object detection...
+├── frontend/
+│   ├── pyproject.toml        # call-aigrapher-ui package (Gradio)
+│   └── src/call_aigrapher_ui/
+└── deploy/databricks/        # requirements.txt generated by pre-commit
 ```
-uv run ui
-```
 
-Then open http://127.0.0.1:7861. The "Backends" panel mirrors the CLI flags:
-detector (`mser`/`yolo` with weights path and confidence), optional classifier
-checkpoint, and stylizer (`baseline`, `neural` or `latent` with its model
-paths and the alphabet dataset). The latent backend still requires a
-classifier so each character finds its reference glyph.
+Generated artifacts (`dataset/`, `models/`, `runs/`, `junit/`) stay at the repository root and are git-ignored.
 
-## Experiments
+# Build and Test
+
+All commands run through `uv run`, no manual activation needed.
+
+- Check what the linters would change across all files (not only staged files).
+  ```
+  uv run pre-commit run --all-files
+  ```
+- Run all unit tests.
+  ```
+  uv run pytest
+  ```
+- Measure code coverage.
+  ```
+  uv run coverage run -m pytest
+  ```
+- Visualize code coverage.
+
+  - View code coverage summary in terminal.
+    ```
+    uv run coverage report
+    ```
+  - Generate HTML code coverage report.
+    ```
+    uv run coverage html
+    ```
+  - View code coverage directly inside your code.
+    ```
+    uv run coverage xml
+    ```
+    _Install the Coverage Gutters extension if you are using Visual Studio Code, and click on "Watch" on the left side of the status bar in the bottom of the IDE to visualize the code coverage._
+
+# Experiments
+
+The research history behind the product, oldest first. Each script lives in `backend/experiments/`.
 
 ### Experiment 1
 
@@ -201,16 +287,22 @@ We can see as the discriminator is able to reduce the losses when picture is cha
 |  4   | GANS with one discriminator |![Experiment 4](./assets/gif/exp_4.gif)   |
 |  5   | GANS with WGAN-GP |![Experiment 5](./assets/gif/exp_5.gif)   |
 
-
 ### Experiment 6
 
-Include Autoencoder Denosing.
+Include Autoencoder Denoising.
 
 ![Experiment 6](./assets/gif/exp_6_losses.png)
 
 ![Experiment 6](./assets/gif/exp_6.gif)
 
 We can observe a high noise removal performance within a few epochs of training. However, the letters 'c' and 'e' are very similar. This might be due to the limited variability of the sample, as only one sample per character is available.
+
+Reproduce it today with:
+
+```
+uv run python backend/experiments/train.py     # GANS training (experiments 1-5)
+uv run python backend/experiments/denoise.py   # autoencoder denoising (experiment 6)
+```
 
 ### Experiment 7
 
@@ -223,105 +315,18 @@ https://stackoverflow.com/questions/40443988/python-opencv-ocr-image-segmentatio
 
 We can see a high level character recognition but we still seeing areas with multiple characters. Therefore, Object Detection with RNN is needed.
 
-## Project Structure
-
-The repository is a [uv workspace](https://docs.astral.sh/uv/concepts/workspaces/) split into backend and frontend:
-
-```bash
-├── pyproject.toml               # workspace root + shared tooling config
-├── assets                       # reference images, gifs and base weights
-│   ├── gif
-│   ├── handwriting
-│   ├── myhandw
-│   └── yolov8n.pt
-├── backend
-│   ├── experiments              # early GAN/denoising experiment scripts
-│   ├── pyproject.toml           # call-ai-grapher package + CLI entry points
-│   └── src/call_ai_grapher      # pipeline, models, dataset, object detection...
-│       ├── cli                  # command line entry point modules
-│       └── config               # experiment settings (gans_config, denoise_config)
-├── frontend
-│   ├── pyproject.toml           # call-aigrapher-ui package (Gradio)
-│   ├── src/call_aigrapher_ui    # web app
-│   └── tests
-└── deploy/databricks            # requirements.txt generated by pre-commit
-```
-
-Generated artifacts (`dataset/`, `models/`, `runs/`, `junit/`) stay at the repository root and are git-ignored.
-
-## Installation process
-
-Install [uv](https://docs.astral.sh/uv/getting-started/installation/).
-
-Install all the dependencies. Also creates the virtual environment (`.venv`) if it didn't exist yet.
-```
-uv sync --all-groups
-```
-
-_If the installation fails you are probably missing the required Python version. uv installs it automatically. Depending on your internet connection and your machine the installation can take a few minutes._
-
-Install the pre-commit hooks.
-```
-uv run pre-commit install
-```
-## Run Gans Training
-
-```
-uv run python backend/experiments/train.py
-```
-
-## Run Autoencoder Denoising
-
-```
-uv run python backend/experiments/denoise.py
-```
-
 ## Run Jupyter (FYI)
 
 ```
 uv run jupyter notebook
 ```
-## Software dependencies
-- Install [uv](https://docs.astral.sh/uv/getting-started/installation/).
-## Resources
+
+# Resources
+
 - [uv - Basic usage](https://docs.astral.sh/uv/guides/projects/)
 - [pyenv - Usage](https://github.com/pyenv/pyenv#usage)
-
-# Build and Test
-
-Please activate the virtual environment by using `source .venv/bin/activate` before running the commands below, or prefix all commands with `uv run`.
-
-- Run pre-commit hooks for all files (not only staged files) manually.
-  ```
-  pre-commit run --all-files
-  ```
-- Run all unit tests.
-  ```
-  pytest
-  ```
-- Measure code coverage.
-  ```
-  coverage run -m pytest
-  ```
-- Visualize code coverage.
-
-  - View code coverage summary in terminal.
-    ```
-    coverage report
-    ```
-  - Generate HTML code coverage report.
-    ```
-    coverage html
-    ```
-  - View code coverage directly inside your code.
-    ```
-    coverage xml
-    ```
-    _Install the Coverage Gutters extension if you are using Visual Studio Code, and click on "Watch" on the left side of the status bar in the bottom of the IDE to visualize the code coverage._
+- [CRAFT text detector](https://github.com/clovaai/CRAFT-pytorch?tab=readme-ov-file)
 
 # Contribute
 
 Read [here](./CONTRIBUTING.md) how you can contribute to make our code better.
-
-
-https://github.com/clovaai/CRAFT-pytorch?tab=readme-ov-file

--- a/backend/src/call_ai_grapher/pipeline/detector.py
+++ b/backend/src/call_ai_grapher/pipeline/detector.py
@@ -38,6 +38,12 @@ class CharacterDetector:
         """
         gray = self._to_gray(page)
         scaled = cv2.resize(gray, None, fx=self.scale, fy=self.scale, interpolation=cv2.INTER_CUBIC)
+        # TODO(ft/char-detector): MSER defaults cap region area at 14400 px *after* the
+        # scale=2.0 upscale, so characters bigger than ~85 px per side in the source page are
+        # silently dropped (e.g. full-resolution phone photos of a page yield zero detections).
+        # Make the area window adaptive (normalize by image size, or auto-downscale/tile large
+        # pages before MSER) and add a regression test with a big real photo such as
+        # assets/gif/exp_7.jpeg (3072x4096), which currently detects nothing.
         regions, _ = cv2.MSER_create().detectRegions(scaled)
 
         boxes = []


### PR DESCRIPTION
## Summary
Reorganizes the README so a new user has a clear path from zero, and records a known detection limitation as a code TODO.

## What Changed
- README reordered for onboarding: Installation first, then a Quick start that works with zero training (`uv run ui` / `uv run improve-document`), then the model training steps renumbered 1-5 in dependency order (alphabet -> detector -> classifier -> pix2pix stylizer -> latent regulator), each ending with the exact `improve-document` flags that activate it.
- Project structure tree rewritten at fixed shallow depth (top level + backend/frontend + src packages) so it stays stable as modules are added; no per-module listing.
- Fixed stale references after the workspace restructure: `improve_document.py` -> `improve-document`, `build_alphabet.py` -> `build-alphabet`; Build and Test commands now consistently use `uv run`.
- Deduplicated the roadmap table rows (stylizer and blend regulator appeared twice).
- Moved the historical Experiments section after Build and Test, folded the old "Run Gans Training"/"Run Autoencoder Denoising" sections into experiment 6 as reproduction commands (`backend/experiments/...`), moved the stray CRAFT link into Resources.
- Added a TODO in `CharacterDetector.detect`: MSER default `max_area=14400` applies *after* the 2x upscale, so characters larger than ~85 px per side in the source page are silently dropped (full-resolution phone photos detect nothing). Notes the fix direction (adaptive area window or auto-downscale) and suggests a regression test with `assets/gif/exp_7.jpeg`.

## Testing
- `pre-commit run --files README.md backend/src/call_ai_grapher/pipeline/detector.py`: all hooks pass.
- No behavior change: comment-only edit in detector; README is documentation.
- Verified earlier on this branch's base: entry points respond to `--help`, `uv run pytest -q` -> 47 passed.

## Breaking Changes
- None. Documentation and comment changes only.