### PR TITLE
Document quick start run location and user-provided input

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ uv run pre-commit install
 
 Take the pipeline for a spin before training anything. Out of the box it uses MSER detection plus a simple binarization cleanup, so expect a cleaner, noise-free version of your strokes: an appetizer that proves the plumbing works, not yet the real thing.
 
+Run everything from the repository root: paths like `documents/page.jpeg` are resolved relative to where you invoke the command (uv finds the workspace even from a subfolder, but then your data paths would not match). The scanned page is yours to provide — create the `documents/` folder and drop your image in; it stays git-ignored.
+
 Web app:
 
 ```


### PR DESCRIPTION
## Summary
Documents where to run the quick start commands and that the scanned page is user-provided.

## What Changed
- Quick start now states commands should be run from the repository root: relative paths like `documents/page.jpeg` resolve against the invocation directory (uv finds the workspace from subfolders, but data paths would then not match).
- Clarifies `documents/page.jpeg` does not ship with the repo (git-ignored): create the folder and drop your own scan in before running the example.

## Testing
- Verified `uv run improve-document --help` works both from the repo root and from `backend/`; a missing input raises FileNotFoundError, which motivated the doc note. Markdown-only change otherwise.

## Breaking Changes
- None.
