### PR TITLE
Add whole-page denoising stage behind --denoise-page

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,10 +51,10 @@ uv run ui
 
 Then open the URL printed in the terminal (http://127.0.0.1:7860 by default).
 
-Command line:
+Command line (`--alpha` goes from 0, untouched, to 1, fully cleaned; `--denoise-page` flattens shadows and removes specks across the whole page before detection, recommended for phone photos):
 
 ```
-uv run improve-document --input documents/page.jpeg --output documents/improved.png --alpha 0.8
+uv run improve-document --input documents/page.jpeg --output documents/improved.png --alpha 0.8 --denoise-page
 ```
 
 # Making it actually improve your handwriting

--- a/backend/src/call_ai_grapher/callaigrapher.py
+++ b/backend/src/call_ai_grapher/callaigrapher.py
@@ -1,6 +1,6 @@
 import logging
 from pathlib import Path
-from typing import Optional
+from typing import Callable, Optional
 
 import cv2
 import numpy as np
@@ -20,6 +20,7 @@ class CallAIgraher:
         classifier: Optional[CharClassifier] = None,
         stylizer: Optional[Stylizer] = None,
         recomposer: Optional[Recomposer] = None,
+        preprocessor: Optional[Callable[[np.ndarray], np.ndarray]] = None,
     ):
         """_summary_
         :param detector: character detection stage, defaults to MSER detector
@@ -30,11 +31,15 @@ class CallAIgraher:
         :type stylizer: Optional[Stylizer]
         :param recomposer: page recomposition stage, defaults to paste back
         :type recomposer: Optional[Recomposer]
+        :param preprocessor: optional whole-page cleanup applied before detection, useful for
+            phone photos with shadows and specks
+        :type preprocessor: Optional[Callable[[np.ndarray], np.ndarray]]
         """
         self.detector = detector or CharacterDetector()
         self.classifier = classifier
         self.stylizer = stylizer or Stylizer()
         self.recomposer = recomposer or Recomposer()
+        self.preprocessor = preprocessor
 
     def improve_document(self, input_path: str, output_path: str, alpha: float = 1.0) -> DocumentResult:
         """Improve the handwriting of a scanned document.
@@ -50,6 +55,8 @@ class CallAIgraher:
         :rtype: DocumentResult
         """
         page = self.load_page(input_path)
+        if self.preprocessor is not None:
+            page = self.preprocessor(page)
         result = DocumentResult(source_path=Path(input_path))
 
         result.boxes = self.detector.detect(page)

--- a/backend/src/call_ai_grapher/cli/improve_document.py
+++ b/backend/src/call_ai_grapher/cli/improve_document.py
@@ -5,6 +5,7 @@ from call_ai_grapher import CallAIgraher
 from call_ai_grapher.pipeline.factory import (
     build_classifier,
     build_detector,
+    build_page_denoiser,
     build_stylizer,
 )
 
@@ -18,6 +19,11 @@ def _parse_args(argv=None):
     parser.add_argument("--model", default="models/character_detector.pt", help="YOLO weights path (--detector yolo)")
     parser.add_argument("--confidence", type=float, default=0.25, help="minimum detection confidence (--detector yolo)")
     parser.add_argument("--classifier", default=None, help="classifier checkpoint to label characters (optional)")
+    parser.add_argument(
+        "--denoise-page",
+        action="store_true",
+        help="flatten uneven illumination and remove specks across the whole page before detection",
+    )
     parser.add_argument(
         "--stylizer", choices=["baseline", "neural", "latent"], default="baseline", help="stylization backend"
     )
@@ -40,6 +46,7 @@ def main(argv=None):
         grapher = CallAIgraher(
             detector=build_detector(args.detector, args.model, args.confidence),
             classifier=build_classifier(args.classifier),
+            preprocessor=build_page_denoiser(args.denoise_page),
             stylizer=build_stylizer(
                 args.stylizer,
                 stylizer_model=args.stylizer_model,

--- a/backend/src/call_ai_grapher/pipeline/__init__.py
+++ b/backend/src/call_ai_grapher/pipeline/__init__.py
@@ -2,8 +2,16 @@
 
 from call_ai_grapher.pipeline.classifier import CharClassifier
 from call_ai_grapher.pipeline.detector import CharacterDetector
+from call_ai_grapher.pipeline.page_denoiser import PageDenoiser
 from call_ai_grapher.pipeline.recomposer import Recomposer
 from call_ai_grapher.pipeline.stylizer import Stylizer
 from call_ai_grapher.pipeline.yolo_detector import YoloCharacterDetector
 
-__all__ = ["CharacterDetector", "YoloCharacterDetector", "CharClassifier", "Stylizer", "Recomposer"]
+__all__ = [
+    "CharacterDetector",
+    "YoloCharacterDetector",
+    "CharClassifier",
+    "Stylizer",
+    "Recomposer",
+    "PageDenoiser",
+]

--- a/backend/src/call_ai_grapher/pipeline/factory.py
+++ b/backend/src/call_ai_grapher/pipeline/factory.py
@@ -42,6 +42,21 @@ def build_classifier(model_path=None):
     return CharClassifier(model_path)
 
 
+def build_page_denoiser(enabled: bool = False):
+    """Build the whole-page preprocessing stage.
+
+    :param enabled: whether to flatten illumination and remove specks before detection
+    :type enabled: bool
+    :return: the configured preprocessor, or None when disabled
+    :rtype: Optional[PageDenoiser]
+    """
+    if not enabled:
+        return None
+    from call_ai_grapher.pipeline.page_denoiser import PageDenoiser
+
+    return PageDenoiser()
+
+
 def build_stylizer(
     backend: str = "baseline",
     stylizer_model: str = "models/char_stylizer.pt",

--- a/backend/src/call_ai_grapher/pipeline/page_denoiser.py
+++ b/backend/src/call_ai_grapher/pipeline/page_denoiser.py
@@ -1,0 +1,89 @@
+"""Whole-page preprocessing stage.
+
+Phone photos of paper show strong shadows and gray backgrounds, and the
+per-character stylizer only touches detected crops, so anything outside
+them reaches the output untouched. This optional stage normalizes the
+page before detection: dividing each channel by a heavily blurred
+estimate of the background flattens illumination adaptively, and small
+dark connected components (specks) are removed.
+"""
+
+import logging
+
+import cv2
+import numpy as np
+
+
+class PageDenoiser:
+    def __init__(self, kernel_size: int = 51, min_speck_area: int = 12):
+        """_summary_
+        :param kernel_size: background blur window; larger values keep thicker strokes intact
+        :type kernel_size: int
+        :param min_speck_area: dark connected components below this area in px are dropped
+        :type min_speck_area: int
+        """
+        self.kernel_size = kernel_size if kernel_size % 2 == 1 else kernel_size + 1
+        self.min_speck_area = min_speck_area
+
+    def __call__(self, page: np.ndarray) -> np.ndarray:
+        return self.clean(page)
+
+    def clean(self, page: np.ndarray) -> np.ndarray:
+        """Return a copy of `page` with flattened illumination and specks removed.
+
+        :param page: BGR or grayscale page image
+        :type page: np.ndarray
+        :return: cleaned page with the same shape and dtype
+        :rtype: np.ndarray
+        """
+        cleaned = self._flatten_illumination(page)
+        return self._despeckle(cleaned)
+
+    def _flatten_illumination(self, page: np.ndarray) -> np.ndarray:
+        """Divide each channel by its blurred background estimate.
+
+        The background estimate approximates the local paper color, so
+        shadows and gray tints divide out towards white while strokes stay
+        dark. The denominator is clamped so deep shadows cannot blow up
+        the division.
+
+        :param page: input image, uint8 BGR or grayscale
+        :type page: np.ndarray
+        :return: image with an even, white background
+        :rtype: np.ndarray
+        """
+        k = self._fitting_kernel(min(page.shape[:2]))
+        background = cv2.GaussianBlur(page.astype(np.float32), (k, k), 0)
+        normalized = page.astype(np.float32) / np.maximum(background, 32.0) * 255.0
+        return np.clip(normalized, 0, 255).astype(page.dtype)
+
+    def _despeckle(self, page: np.ndarray) -> np.ndarray:
+        """Drop dark connected components smaller than `min_speck_area`.
+
+        :param page: BGR or grayscale page image
+        :type page: np.ndarray
+        :return: page without isolated specks
+        :rtype: np.ndarray
+        """
+        gray = cv2.cvtColor(page, cv2.COLOR_BGR2GRAY) if page.ndim == 3 else page
+        _, binary = cv2.threshold(gray, 0, 255, cv2.THRESH_BINARY_INV + cv2.THRESH_OTSU)
+        count, labels, stats, _ = cv2.connectedComponentsWithStats(binary)
+        specks = (stats[1:, cv2.CC_STAT_AREA] < self.min_speck_area).nonzero()[0] + 1
+        if specks.size == 0:
+            return page
+        mask = np.isin(labels, specks)
+        cleaned = page.copy()
+        cleaned[mask] = 255 if page.ndim == 2 else np.array([255, 255, 255], dtype=page.dtype)
+        logging.info("Removed %d specks", specks.size)
+        return cleaned
+
+    def _fitting_kernel(self, dim: int) -> int:
+        """Return an odd kernel size that fits within `dim` pixels.
+
+        :param dim: smallest image dimension
+        :type dim: int
+        :return: odd kernel size between 3 and `self.kernel_size`
+        :rtype: int
+        """
+        largest_odd = dim if dim % 2 == 1 else dim - 1
+        return max(min(self.kernel_size, largest_odd), 3)

--- a/backend/tests/test_callaigrapher.py
+++ b/backend/tests/test_callaigrapher.py
@@ -45,6 +45,23 @@ def test_improve_document_alpha_zero_keeps_original(tmp_path):
     assert (original == styled).all()
 
 
+def test_preprocessor_is_applied_before_detection(tmp_path):
+    input_path = tmp_path / "page.png"
+    output_path = tmp_path / "improved.png"
+    _write_synthetic_page(input_path)
+
+    calls = []
+
+    def _spy(page):
+        calls.append(page.shape)
+        return page
+
+    grapher = CallAIgraher(detector=_FakeDetector(), preprocessor=_spy)
+    grapher.improve_document(str(input_path), str(output_path), alpha=1.0)
+
+    assert len(calls) == 1
+
+
 def test_load_page_missing_file_raises():
     grapher = CallAIgraher()
     try:

--- a/backend/tests/test_page_denoiser.py
+++ b/backend/tests/test_page_denoiser.py
@@ -1,0 +1,49 @@
+import cv2
+import numpy as np
+from call_ai_grapher.pipeline.page_denoiser import PageDenoiser
+
+
+def _shadowed_noisy_page() -> np.ndarray:
+    page = np.full((120, 200, 3), 240, dtype=np.float32)
+    gradient = np.linspace(0.35, 1.0, 200, dtype=np.float32)
+    page *= gradient[np.newaxis, :, np.newaxis]
+    page = page.astype(np.uint8)
+    cv2.circle(page, (100, 60), 6, 0, -1)
+    rng = np.random.default_rng(7)
+    for _ in range(40):
+        x, y = int(rng.integers(5, 195)), int(rng.integers(5, 115))
+        page[y, x] = 0
+    return page
+
+
+def test_clean_flattens_illumination():
+    page = _shadowed_noisy_page()
+
+    cleaned = PageDenoiser().clean(page)
+
+    gray = cv2.cvtColor(cleaned, cv2.COLOR_BGR2GRAY)
+    shadowed_side = gray[:, :20].mean()
+    lit_side = gray[:, -20:].mean()
+    assert abs(shadowed_side - lit_side) < 30
+
+
+def test_clean_removes_specks_and_keeps_stroke():
+    page = _shadowed_noisy_page()
+
+    cleaned = PageDenoiser(min_speck_area=12).clean(page)
+
+    gray = cv2.cvtColor(cleaned, cv2.COLOR_BGR2GRAY)
+    _, binary = cv2.threshold(gray, 128, 255, cv2.THRESH_BINARY_INV)
+    count, _, stats, _ = cv2.connectedComponentsWithStats(binary)
+    areas = stats[1:, cv2.CC_STAT_AREA]
+    assert (areas > 12).sum() >= 1
+    assert (areas < 12).sum() == 0
+
+
+def test_clean_preserves_shape_and_dtype():
+    page = _shadowed_noisy_page()
+
+    cleaned = PageDenoiser().clean(page)
+
+    assert cleaned.shape == page.shape
+    assert cleaned.dtype == page.dtype


### PR DESCRIPTION
## Summary
Adds an optional whole-page preprocessing stage so phone photos with shadows and specks actually improve, instead of only the detected character crops.

## What Changed
- New `PageDenoiser` stage (`backend/src/call_ai_grapher/pipeline/page_denoiser.py`): divides each channel by a blurred background estimate to flatten uneven illumination adaptively (the classic scanner-app trick), then drops dark connected components smaller than `min_speck_area`.
- `CallAIgraher` accepts an optional `preprocessor` applied right after loading the page and before detection; default `None` keeps current behavior.
- `build_page_denoiser` factory + `--denoise-page` CLI flag on `improve-document` (opt-in).
- Quick start command in the README now includes `--denoise-page` and documents the alpha scale.
- Tests: illumination flattening on a synthetic shadowed page, speck removal with stroke preservation, shape/dtype stability, and orchestrator wiring of the preprocessor.

## Testing
- `uv run pytest -q` -> 51 passed (4 new tests).
- `pre-commit run --all-files`: all hooks pass.
- Real photo check (`assets/myhandw/images/a.png`, mean brightness 152 with strong shadow gradient): before -> 2 characters detected; after `--denoise-page --alpha 0.8` -> 33 characters detected, 4 specks removed, apparent ink coverage (Otsu) drops from 42% to 19%.

## Breaking Changes
- None. The stage is opt-in via `--denoise-page`; without it the pipeline behaves exactly as before.